### PR TITLE
feat: add POSTGRESQL_ALLOW_DANGEROUS_OPERATIONS environment variable …

### DIFF
--- a/servers/postgresql/src/index.ts
+++ b/servers/postgresql/src/index.ts
@@ -22,9 +22,11 @@ class PostgreSQLServer {
     this.logger = new Logger(getLogLevel(), { server: "postgresql" });
 
     const connectionString = getEnvVar("POSTGRESQL_CONNECTION_STRING");
+    const allowDangerousOperations = getEnvVar("POSTGRESQL_ALLOW_DANGEROUS_OPERATIONS", "false") === "true";
     this.postgresqlService = new PostgreSQLService(
       connectionString,
-      this.logger
+      this.logger,
+      allowDangerousOperations
     );
 
     this.server = new Server(
@@ -75,6 +77,16 @@ class PostgreSQLServer {
           args.query,
           args.params
         );
+      case "check_dangerous_operations_allowed":
+        return {
+          success: true,
+          data: {
+            allowed: this.postgresqlService.isDangerousOperationsAllowed(),
+            message: this.postgresqlService.isDangerousOperationsAllowed() 
+              ? "Dangerous operations (INSERT, UPDATE, DELETE, etc.) are ENABLED. Write operations are allowed."
+              : "Dangerous operations are DISABLED. Only read-only operations (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed."
+          }
+        };
       default:
         throw new McpError(
           ErrorCode.MethodNotFound,

--- a/servers/postgresql/src/tools/index.ts
+++ b/servers/postgresql/src/tools/index.ts
@@ -4,7 +4,7 @@ export const postgresqlTools: McpTool[] = [
   {
     name: "execute_query",
     description:
-      "Execute a read-only SQL query on the PostgreSQL database (SELECT queries only, automatically limited to 100 results)",
+      "Execute a SQL query on the PostgreSQL database. When dangerous operations are disabled, only SELECT queries are allowed and automatically limited to 100 results. When enabled, supports INSERT, UPDATE, DELETE, and other write operations.",
     inputSchema: {
       type: "object",
       properties: {
@@ -21,6 +21,16 @@ export const postgresqlTools: McpTool[] = [
         },
       },
       required: ["query"],
+    },
+  },
+  {
+    name: "check_dangerous_operations_allowed",
+    description:
+      "Check if dangerous operations (INSERT, UPDATE, DELETE, etc.) are allowed on this PostgreSQL server. This helps LLMs understand what operations they can perform.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
     },
   },
 ];


### PR DESCRIPTION
…support

- Add support for POSTGRESQL_ALLOW_DANGEROUS_OPERATIONS env var to control write operations
- When enabled, allows INSERT, UPDATE, DELETE and other write operations
- When disabled (default), restricts to read-only operations with safety checks
- Add check_dangerous_operations_allowed tool to query current safety mode
- Update transaction handling to use read-write when dangerous operations are allowed
- Remove automatic LIMIT 100 when dangerous operations are enabled
- Maintain backward compatibility with default read-only behavior

🤖 Generated with [Claude Code](https://claude.ai/code)